### PR TITLE
[fix] argument mismatch of SvmA evaluation function

### DIFF
--- a/project/src/evaluation/eval_pipeline.py
+++ b/project/src/evaluation/eval_pipeline.py
@@ -70,7 +70,7 @@ def eval_pipeline(model):
 
     elif model == 'SvmA':
         feature_indices = calculate_feature_indices(X_train, y_train)
-        SvmA_eval(X_train, X_test, y_train, y_test, feature_indices, model)
+        SvmA_eval(X_test, y_test, model)
 
     else:
         model_filename = f"{MODEL_PKL_PATH}/{model_type}/{model}.pkl"


### PR DESCRIPTION
## Description
SvmA evaliation function arguments number mismatch bug fix

## Changes 
- remove X_train, y_train arguments from SvmA evaluation function

## Test
run_eval.ps1